### PR TITLE
Add "position" option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = function styleInject (css, returnValue) {
+module.exports = function styleInject (css, returnValue, opts) {
   if (typeof document === 'undefined') {
     return returnValue;
   }
@@ -6,7 +6,16 @@ module.exports = function styleInject (css, returnValue) {
   var head = document.head || document.getElementsByTagName('head')[0];
   var style = document.createElement('style');
   style.type = 'text/css';
-  head.appendChild(style);
+  
+  if (opts && opts.position === "top") {
+    if (head.firstChild) {
+      this.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
   
   if (style.styleSheet){
     style.styleSheet.cssText = css;

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ module.exports = function styleInject (css, returnValue, opts) {
   var style = document.createElement('style');
   style.type = 'text/css';
   
-  if (opts && opts.position === "top") {
+  if (opts && opts.insertAt === "top") {
     if (head.firstChild) {
-      this.insertBefore(style, head.firstChild);
+      head.insertBefore(style, head.firstChild);
     } else {
       head.appendChild(style);
     }


### PR DESCRIPTION
Sometimes, it is not desirable to always inject the `<style>` tag at the end of `<head>`, since you might want to override some of the styles in CSS.

This adds a third parameter for custom options, where you can specify:
```javascript
{
  position: "top",
}
```

Works in a similar way as: https://github.com/webpack-contrib/style-loader#insertat