### PR TITLE
feat(style-inject): enable AMP inject

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ styleInject(css, options);
 ### insertAt
 
 Type: `string`<br>
-Possible values: `top`<br>
+Possible values: `top`, `amp`<br>
 Default: `undefined`
 
-Insert `style` tag to specific position of `head` element.
+Insert `style` tag to specific position of `head` element. If `amp` was selected, the whole CSS string gets injected in a single `<style amp-custom>...</style>` element, according to the [AMP docs](https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/?format=websites#add-styles-to-a-page).
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,10 @@ export default function styleInject(css, { insertAt } = {}) {
 
   const ampStyleSelector = 'style[amp-custom]'
 
-  const { appendChild, insertBefore, firstChild, querySelector } =
+  const head =
     document.head || document.getElementsByTagName('head')[0]
   const style = document.createElement('style')
-  const ampStyle = querySelector(ampStyleSelector) || style
+  const ampStyle = head.querySelector(ampStyleSelector) || style
 
   switch (insertAt) {
     // AMP only allows a single <script> tag with an 'amp-custom' attribute set
@@ -14,8 +14,8 @@ export default function styleInject(css, { insertAt } = {}) {
       style.setAttribute('amp-custom', true)
       ampStyle.innerText += css
 
-      if (!querySelector(ampStyleSelector)) {
-        appendChild(ampStyle)
+      if (!head.querySelector(ampStyleSelector)) {
+        head.appendChild(ampStyle)
       }
       break
     // By default styleInject appends a new <style> tag in <head>
@@ -30,9 +30,9 @@ export default function styleInject(css, { insertAt } = {}) {
       }
 
       if (firstChild && insertAt === 'top') {
-        insertBefore(style, firstChild)
+        head.insertBefore(style, firstChild)
       } else {
-        appendChild(style)
+        head.appendChild(style)
       }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,7 @@ export default function styleInject(css, { insertAt } = {}) {
 
   const ampStyleSelector = 'style[amp-custom]'
 
-  const head =
-    document.head || document.getElementsByTagName('head')[0]
+  const head = document.head || document.getElementsByTagName('head')[0]
   const style = document.createElement('style')
   const ampStyle = head.querySelector(ampStyleSelector) || style
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,23 +1,38 @@
 export default function styleInject(css, { insertAt } = {}) {
   if (!css || typeof document === 'undefined') return
 
-  const head = document.head || document.getElementsByTagName('head')[0]
+  const ampStyleSelector = 'style[amp-custom]'
+
+  const { appendChild, insertBefore, firstChild, querySelector } =
+    document.head || document.getElementsByTagName('head')[0]
   const style = document.createElement('style')
-  style.type = 'text/css'
+  const ampStyle = querySelector(ampStyleSelector) || style
 
-  if (insertAt === 'top') {
-    if (head.firstChild) {
-      head.insertBefore(style, head.firstChild)
-    } else {
-      head.appendChild(style)
-    }
-  } else {
-    head.appendChild(style)
-  }
+  switch (insertAt) {
+    // AMP only allows a single <script> tag with an 'amp-custom' attribute set
+    case 'amp':
+      style.setAttribute('amp-custom', true)
+      ampStyle.innerText += css
 
-  if (style.styleSheet) {
-    style.styleSheet.cssText = css
-  } else {
-    style.appendChild(document.createTextNode(css))
+      if (!querySelector(ampStyleSelector)) {
+        appendChild(ampStyle)
+      }
+      break
+    // By default styleInject appends a new <style> tag in <head>
+    case 'top':
+    default:
+      style.type = 'text/css'
+
+      if (style.styleSheet) {
+        style.styleSheet.cssText = css
+      } else {
+        style.appendChild(document.createTextNode(css))
+      }
+
+      if (firstChild && insertAt === 'top') {
+        insertBefore(style, firstChild)
+      } else {
+        appendChild(style)
+      }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,8 @@ export default function styleInject(css, { insertAt } = {}) {
         style.appendChild(document.createTextNode(css))
       }
 
-      if (firstChild && insertAt === 'top') {
-        head.insertBefore(style, firstChild)
+      if (head.firstChild && insertAt === 'top') {
+        head.insertBefore(style, head.firstChild)
       } else {
         head.appendChild(style)
       }

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default function styleInject(css, { insertAt } = {}) {
   switch (insertAt) {
     // AMP only allows a single <script> tag with an 'amp-custom' attribute set
     case 'amp':
-      style.setAttribute('amp-custom', true)
+      style.setAttribute('amp-custom', '')
       ampStyle.innerText += css
 
       if (!head.querySelector(ampStyleSelector)) {


### PR DESCRIPTION
This PR adds the functionality to inject the CSS string in a `<style amp-custom>...</style>` tag, as intended by the [AMP project](https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/?format=websites#add-styles-to-a-page).

**Functionality**: It queries the `<head>` for an already available `amp-custom` tag, and appends the CSS string to its contents. If no `amp-custom` was found, it appends a new `<style amp-custom />` element as a child of the document's head.

The previous functionality was preserved, so it's still backwards compatible.