### PR TITLE
Remove redundant .type = 'text/css'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ export default function styleInject(css, { insertAt } = {}) {
 
   const head = document.head || document.getElementsByTagName('head')[0]
   const style = document.createElement('style')
-  style.type = 'text/css'
 
   if (insertAt === 'top') {
     if (head.firstChild) {


### PR DESCRIPTION
The `type="text/css"` attribute is the implicit default for <style> elements. There’s no need to specify it in HTML source code, and there’s no need to add the attribute when creating a <style> element programmatically.

https://mathiasbynens.be/notes/html5-levels#level-1