### PR TITLE
perf: added support fo SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,51 @@ const css = `
 styleInject(css, options);
 ```
 
+### Usage with Next (SSR)
+
+If using a library that use `style-inject` for use css modules in Next.js,
+you need to inject styles during SSR, here's an example:
+
+```jsx
+// file: pages/_document.js
+
+import React from 'react';
+import { SSR_INJECT_ID } from 'style-inject';
+
+const SSRInjectStyles = () => {
+    if (!globalThis[SSR_INJECT_ID]) return null
+
+    return (
+        <>
+            {globalThis[SSR_INJECT_ID].map((module) => (
+                <style id={module.id} key={module.id}>
+                    {module.css}
+                </style>
+            ))}
+        </>
+    )
+}
+
+const Document = (props) => {
+    const { locale } = props
+    return (
+        <Html lang={locale}>
+            <Head>
+                {/* Inject styles during ssr */}
+                <SSRInjectStyles />
+                {/* ... */}
+            </Head>
+            <body>
+            {/* ... */}
+            </body>
+        </Html>
+    )
+}
+
+export default Document
+
+```
+
 ## Options
 
 ### insertAt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-inject",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Inject style tag to document head.",
   "main": "dist/style-inject.js",
   "module": "dist/style-inject.es.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+export const SSR_INJECT_ID = '__styleInject_SSR_MODULES';
+
 /**
  * Inject CSS into the head tag
  * @param css The CSS string to inject
@@ -5,7 +7,14 @@
  * @param insertAt Where to insert the style tag
  */
 export default function styleInject(css, id,  { insertAt } = {}) {
-  if (!css || typeof document === 'undefined') return
+  if (!css) return
+  if (typeof document === 'undefined') {
+    if (globalThis) {
+      globalThis[SSR_INJECT_ID] = globalThis[SSR_INJECT_ID] || [];
+      globalThis[SSR_INJECT_ID].push({ css, id });
+    }
+    return;
+  }
 
   if (document.getElementById(id)) {
     return;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,18 @@
-export default function styleInject(css, { insertAt } = {}) {
+/**
+ * Inject CSS into the head tag
+ * @param css The CSS string to inject
+ * @param id The ID of the style tag
+ * @param insertAt Where to insert the style tag
+ */
+export default function styleInject(css, id,  { insertAt } = {}) {
   if (!css || typeof document === 'undefined') return
 
+  if (document.getElementById(id)) {
+    return;
+  }
   const head = document.head || document.getElementsByTagName('head')[0]
   const style = document.createElement('style')
+  style.id = id
   style.type = 'text/css'
 
   if (insertAt === 'top') {


### PR DESCRIPTION
This is needed to allow component library that  use `rollup-plugin-postcss` to inject style during SSR render, for example using Next.js.