### PR TITLE
✨ Feature/insert before

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Default: `undefined`
 
 Insert `style` tag to specific position of `head` element.
 
+### insertBeforeQuerySelector
+
+Type: `string`<br>
+Possible values: any value that can be passed to `head.querySelector`<br>
+Default: `undefined`
+
+Insert `style` tag to above a specific tag in the `head` element.
+
 ## License
 
 MIT &copy; [EGOIST](https://github.com/egoist)

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,24 @@
-export default function styleInject(css, { insertAt } = {}) {
+export default function styleInject(css, { insertAt, insertBeforeQuerySelector } = {}) {
   if (!css || typeof document === 'undefined') return
 
   const head = document.head || document.getElementsByTagName('head')[0]
+  /** node to insert style before */
+  const insertBeforeNode = insertBeforeQuerySelector && head.querySelector(insertBeforeQuerySelector);
   const style = document.createElement('style')
   style.type = 'text/css'
 
-  if (insertAt === 'top') {
+  // if an insertBeforeNode is found, insert before that node
+  if (insertBeforeNode) {
+    head.insertBefore(style, insertBeforeNode)
+  } else if (insertAt === 'top') {
+    // if an insertAt 'top' is passed, insert before head's first child
     if (head.firstChild) {
       head.insertBefore(style, head.firstChild)
     } else {
       head.appendChild(style)
     }
   } else {
+    // append child to head
     head.appendChild(style)
   }
 


### PR DESCRIPTION
Add `insertBeforeQuerySelector` option allowing the user to inject css above a specific document.
This solves issues related CSS overriding.